### PR TITLE
Update Deian release to buster

### DIFF
--- a/omnia/create-medkit.sh
+++ b/omnia/create-medkit.sh
@@ -15,7 +15,7 @@
 #
 
 MIRROR="http://ucho.ignum.cz/debian/"
-DEBVER="stretch"
+DEBVER="buster"
 HOSTNAME="turris"
 PASSWORD="turris"
 

--- a/omnia/files/interfaces
+++ b/omnia/files/interfaces
@@ -17,6 +17,6 @@ iface br0 inet static
 	netmask 255.255.255.0
 
 # WAN
-#auto eth2
-#iface eth2 inet dhcp
+#auto eth1
+#iface eth1 inet dhcp
 


### PR DESCRIPTION
Update Debian release to buster
Exchange network interface names after the Linux kernel enumearation changed